### PR TITLE
fixed a wrong punctuation

### DIFF
--- a/WordPressSecurityWhitePaper.html
+++ b/WordPressSecurityWhitePaper.html
@@ -49,7 +49,7 @@
 	<li>Phase 5: Launch. WordPress version is launched and made available in the WordPress Admin for updates.</li>
 </ul>
 <h3>Version Numbering and Security Releases</h3>
-<p>A major WordPress version is dictated by the first two sequences. For example, 3.5 is a major release, as is 3.6, 3.7, or 4.0. There isn't a "WordPress 3" or "WordPress 4" and each major release is referred to by its numbering, e.g., "WordPress 3.9."</p>
+<p>A major WordPress version is dictated by the first two sequences. For example, 3.5 is a major release, as is 3.6, 3.7, or 4.0. There isn't a "WordPress 3" or "WordPress 4" and each major release is referred to by its numbering, e.g., "WordPress 3.9".</p>
 
 <p>Major releases may add new user features and developer APIs. Though typically in the software world, a "major" version means you can break backwards compatibility, WordPress strives to never break backwards compatibility. Backwards compatibility is one of the project's most important philosophies, with the aim of making updates much easier on users and developers alike.</p>
 


### PR DESCRIPTION
`There isn't a "WordPress 3" or "WordPress 4" and each major release is referred to by its numbering, e.g., "WordPress 3.9."`

contains a dot in "WordPress 3.9." at the end, which is supposed to close the sentence and therefore belongs after the double quote:

`There isn't a "WordPress 3" or "WordPress 4" and each major release is referred to by its numbering, e.g., "WordPress 3.9".`

The punctuation is important in this context, as version numbering is explained and WordPress version numbers don't have a trailing dot.