### PR TITLE
Translated the 'An Overview of WordPress' section.

### DIFF
--- a/Working Translations/pt-br/WordPress-WhitePaperSobreSegurança.html
+++ b/Working Translations/pt-br/WordPress-WhitePaperSobreSegurança.html
@@ -21,23 +21,23 @@
 
 <p>Desenvolvedores e adminstradores de sites devem prestar atenção em particular para o uso correto das APIs do núcleo, e na configuração do servidor subjacente o qual tem sido fonte de vulnerabilidades comuns, assim como assegurando que todos os usuários empreguem senhas fortes para acessar o Wordpress.</p>
 <h2>Uma Visão Geral do Wordpress</h2>
-<p>WordPress a free and open source content management system (CMS). It is the most widely-used CMS software in the world and it powers more than 23% of the top 10 million websites<sup id="ref1"><a href="#footnote1">1</a></a></sup>, giving it an estimated 60% market share of all sites using a CMS.</p>
+<p>Wordpress um sistema de gerenciamento de conteúdo (do inglês Content Management System – CMS) de código-fonte aberto e gratuito. É o programa CMS mais utilizado no mundo e ele alimenta mais de 23% dos top 10 milhões dos sites<sup id="ref1"><a href="#footnote1">1</a></a></sup>, dando-lhe uma estimativa de 60% da quota de mercado de todos os sites usando um CMS.</p>
 
-<p>WordPress is licensed under the General Public License (GPLv2 or later) which provides four core freedoms, and can be considered as the WordPress "bill of rights":</p>
+<p>Wordpress é licencisado sobre a Licença Pública Geral (do inglês General Public License - GPL) (GPLv2 ou posterior) que prevê quatro liberdades fundamentais, e que podem ser consideradas como a "declaração de direitos" do Wordpress:</p>
 <ol>
-	<li>The freedom to run the program, for any purpose.</li>
-	<li>The freedom to study how the program works, and change it to make it do what you wish.</li>
-	<li>The freedom to redistribute.</li>
-	<li>The freedom to distribute copies of your modified versions to others.</li>
+	<li>A liberdade para rodar o programa, para qualquer finalidade.</li>
+	<li>A liberdade para estudar como o programa funciona, e alterá-lo para fazer aquilo que você desejar.</li>
+	<li>A liberdade para redistribuir.</li>
+	<li>A liberdade para distribuir cópias da sua versão modificada para outros.</li>
 </ol>
-<h3>The WordPress Core Leadership Team</h3>
-<p>The WordPress project is a meritocracy, run by a core leadership team, and led by its co-creator and lead developer, Matt Mullenweg. The team governs all aspects of the project, including core development, WordPress.org, and community initiatives.</p>
+<h3>O Time de Liderança do Núcleo do WordPress</h3>
+<p>O projeto Wordpress é uma meritocracia, gerido pelo time de liderança do núcleo, e liderado pelo seu co-criador e desenvolvedor líder, Matt Mullenweg. O time governa todos os aspectos do projeto, incluíndo desenvolvimento do núcleo, Wordpress.org, e iniciativas da comunidade.</p>
 
-<p>The Core Leadership Team consists of Matt Mullenweg, five lead developers, and more than a dozen core developers with permanent commit access. These developers have final authority on technical decisions, and lead architecture discussions and implementation efforts.</p>
+<p>O Time de Liderança do Núcleo consiste de Matt Mullenweg, cinco desenvolvedores líder, e mais de uma dúzia de desenvolvedores do núcleo com acesso permanente para comitar. Estes desenvolvedores tem autoridade final em decisões técnicas, e lideram discussões sobre arquitetura e esforços de implementação.</p>
 
-<p>WordPress has a number of contributing developers. Some of these are former or current committers, and some are likely future committers. These contributing developers are trusted and veteran contributors to WordPress who have earned a great deal of respect among their peers. As needed, WordPress also has guest committers, individuals who are granted commit access, sometimes for a specific component, on a temporary or trial basis.</p>
+<p>Wordpress tem um número de desenvolvedores contribuintes. Alguns destes são ex ou atuais comitadores, e alguns são possíveis comitadores futuros. Estes desenvolvedores contribuintes são confiáveis e contribuidores veteranos para o Wordpress os quais ganharam grande respeito entre seus pares. Conforme necessário, WordPress também tem comitadores convidados, indivíduos que são concedidos acesso à comitar, algumas vezes para um componente específico, temporariamente ou a título de experiência.</p>
 
-<p>The core and contributing developers primarily guide WordPress development. Every version, hundreds of developers contribute code to WordPress. These core contributors are volunteers who contribute to the core codebase in some way.</p>
+<p>Os desenvolvedores do núcleo e contribuintes orientam principalmente o desenvolvimento do Wordpress. A cada vesão, centenas de desenvolvedores contribuem código para o Wordpress. Estes contribuintes do núcleo são voluntários que contribuem para a base de código do núcleo de alguma maneira.</p>
 <h3>The WordPress Release Cycle</h3>
 <p>Each WordPress release cycle is led by one or more of the core WordPress developers. A release cycle usually lasts around 4 months from the initial scoping meeting to launch of the version.</p>
 


### PR DESCRIPTION
More text translated to pt-br.
Kept references for CMS and GPL, which are well known amongst developers.