### PR TITLE
Start translating 'The WordPress Release Cycle' section to pt-br.

### DIFF
--- a/Working Translations/pt-br/WordPress-WhitePaperSobreSegurança.html
+++ b/Working Translations/pt-br/WordPress-WhitePaperSobreSegurança.html
@@ -38,8 +38,8 @@
 <p>Wordpress tem um número de desenvolvedores contribuintes. Alguns destes são ex ou atuais comitadores, e alguns são possíveis comitadores futuros. Estes desenvolvedores contribuintes são confiáveis e contribuidores veteranos para o Wordpress os quais ganharam grande respeito entre seus pares. Conforme necessário, WordPress também tem comitadores convidados, indivíduos que são concedidos acesso à comitar, algumas vezes para um componente específico, temporariamente ou a título de experiência.</p>
 
 <p>Os desenvolvedores do núcleo e contribuintes orientam principalmente o desenvolvimento do Wordpress. A cada vesão, centenas de desenvolvedores contribuem código para o Wordpress. Estes contribuintes do núcleo são voluntários que contribuem para a base de código do núcleo de alguma maneira.</p>
-<h3>The WordPress Release Cycle</h3>
-<p>Each WordPress release cycle is led by one or more of the core WordPress developers. A release cycle usually lasts around 4 months from the initial scoping meeting to launch of the version.</p>
+<h3>O ciclo de lançamento do Wordpress</h3>
+<p>Cada ciclo de lançamento do WordPress é liderado por um ou mais dos principais desenvolvedores do WordPress. Um ciclo de lançamento geralmente dura cerca de 4 meses, a partir da reunião inicial de escopo até o lançamento da nova versão.</p>
 
 <p>A release cycle follows the following pattern<sup id="ref2"><a href="#footnote2">2</a></sup>:</p>
 <ul>


### PR DESCRIPTION
Continue to translate the document to pt-br.
Props go to @heliocj.