### PR TITLE
Remove extra space before comma

### DIFF
--- a/WordPressSecurityWhitePaper.html
+++ b/WordPressSecurityWhitePaper.html
@@ -168,7 +168,7 @@
 
 <p><em>Authored by </em>Sara Rosso </p>
 
-<p><em>Contributions from</em> Barry Abrahamson, Michael Adams, Jon Cave, Helen Hou-Sand&iacute; , Dion Hulse, Mo Jangda, Paul Maiorana</p>
+<p><em>Contributions from</em> Barry Abrahamson, Michael Adams, Jon Cave, Helen Hou-Sand&iacute;, Dion Hulse, Mo Jangda, Paul Maiorana</p>
 
 <p><em>Version 1.0 March 2015</em></p>
 


### PR DESCRIPTION
There's an extra space before comma in the "Contributions from" line.
