### PR TITLE
Add a section on HTML and JavaScript in post content

### DIFF
--- a/WordPressSecurityWhitePaper.html
+++ b/WordPressSecurityWhitePaper.html
@@ -457,6 +457,12 @@ document.addEventListener('DOMContentLoaded', function() {
 <p>When processing XML, WordPress disables the loading of custom XML entities to prevent both External Entity and Entity Expansion attacks. Beyond PHP's core functionality, WordPress does not provide additional secure XML processing API for plugin authors.</p>
 <h4>SSRF (Server Side Request Forgery) Attacks</h4>
 <p>Outbound HTTP(S) requests issued by WordPress are filtered to prevent access to loopback and private IP addresses. They are also filtered to restrict requests to certain standard HTTP ports (`80`, `443`, and `8080`). This filtering is done by the `wp_http_validate_url()` function, and takes place automatically when the `wp_safe_remote_get()` and `wp_safe_remote_post()` functions are used.</p>
+<h4>HTML and JavaScript in Post Content</h4>
+<p>WordPress intentionally permits trusted users to publish arbitrary HTML and JavaScript inside posts, pages, and other content. This is governed by the <code>unfiltered_html</code> capability, which is granted by default to administrators and editors on single-site installations, and restricted to Super Admins on Multisite. It is what allows site owners and editorial staff to embed custom widgets, inline analytics scripts, third-party embed code, and similar trusted markup directly in posts without those snippets being stripped by sanitization.</p>
+
+<p>Content created by users in lower-privilege roles (Author, Contributor) is filtered through the KSES library to remove HTML elements and attributes outside a known-safe allowlist. A Contributor who submits a post containing a <code>&lt;script&gt;</code> tag will have that tag removed before the content is stored.</p>
+
+<p>Because the ability to publish arbitrary HTML and JavaScript is a privileged feature rather than a vulnerability, the regular receipt of reports describing it as such is expected. Site owners who wish to remove it from a given role can do so by unsetting the <code>unfiltered_html</code> capability via the role and capability APIs; hosts and security plugins frequently apply this restriction by default in shared or untrusted environments.</p>
 <h2>WordPress Plugin and Theme Security</h2>
 <h3>The Default Theme</h3>
 <p>WordPress requires a theme to be enabled to render content visible on the front end. The default themes which ship with core WordPress have been vigorously reviewed and tested for security reasons by both the team of theme developers plus the core development team.</p>


### PR DESCRIPTION
## Summary

Closes #52. Adds an `<h4>` subsection under `Further Security Risks and Concerns` titled `HTML and JavaScript in Post Content`, placed alongside the existing XXE and SSRF entries. 

Does not remove the brief existing OWASP A3 mention, but after #88 merges, that reference will be eliminated, and a shorter OWASP summary mention will appear under the A05:2025 — Injection paragraph. That new paragraph still contains a brief `unfiltered_html`/KSES sentence:

> Content submitted by untrusted users is filtered through the KSES library … while trusted roles with the `unfiltered_html` capability … are permitted to publish raw HTML and JavaScript by design.

The new section explains that the `unfiltered_html` capability is an intentional design choice rather than a vulnerability, covering:

- Which roles have the capability by default. (Administrators and editors on single-site, Super Admins on Multisite.)
- What KSES does for content created by Author and Contributor roles.
- How site owners can revoke `unfiltered_html` per role when their threat model requires it, and that hosts and security plugins often do this by default.

The framing matches @johnbillion's note in #52 that this is the most common subject of invalid reports received by the security team — the section is informational, not alarmist.

## Notes for the reviewer

- Self-contained, no new footnotes. (Avoids a numbering collision with #90 if both are merged.)
- Independent of #88 and #90. Can merge in any order. If #88 lands first, this section complements the one-line mention added there.
- The committed text was generated, reviewed, and refined with Claude and Codex LLMs.